### PR TITLE
dep2bazel: generate lower case names for go_repository

### DIFF
--- a/dep2bazel/main.go
+++ b/dep2bazel/main.go
@@ -80,7 +80,7 @@ func bazelName(importpath string) string {
 	}
 	slice = append(slice, parts[1:]...)
 	name := strings.Join(slice, "_")
-	return strings.NewReplacer("-", "_", ".", "_").Replace(name)
+	return strings.ToLower(strings.NewReplacer("-", "_", ".", "_").Replace(name))
 }
 
 func githubTarball(url string, revision string) (*RemoteTarball, error) {


### PR DESCRIPTION
My project uses `github.com/DataDog/datadog-go` as a dependency, so gazelle is generating the external dependency `"@com_github_datadog_datadog_go//statsd:go_default_library",` but dep2bazel is generating the following go_repository. This PR forces all external names to be lower case.

```
    go_repository(
        name = "com_github_DataDog_datadog_go",
        importpath = "github.com/DataDog/datadog-go",
        urls = ["https://github.com/DataDog/datadog-go/archive/e67964b4021ad3a334e748e8811eb3cd6becbc6e.tar.gz"],
        strip_prefix = "datadog-go-e67964b4021ad3a334e748e8811eb3cd6becbc6e/",
        build_file_generation = "on",
        build_file_proto_mode = "disable",
    )
```